### PR TITLE
Bug/cs/persistent school config reminder

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -253,6 +253,11 @@ class ConfigurationTests(BaseMainTestCase):
             self.assertEqual(get_data[key], payload[key])
         self.assertIn('timestamp', get_data.keys())
 
+    def test_no_persistent_set_config_reminder(self):
+        req = self.app.get('/')
+        self.ok(req)
+        self.assertNotIn('configuration', req.body)
+
 
 class UserSurveyTests(BaseMainTestCase):
     """Test the user survey

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -6,7 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
-  <h1>Please configure your school settings <a href="/school">here</a>.
   <div id="root" style="height: 100%"></div>
 </body>
 </html>


### PR DESCRIPTION
Issue with the new UI is that there was a persistent "please fill out your school configuration" text blob on the page, even after the user had filled out the form. This takes it out and adds a simple test to make sure it's not present in the `index.html`.

So it turns this:

![captura de pantalla 2017-02-03 a las 12 20 46 pm](https://cloud.githubusercontent.com/assets/4930129/22601052/3ec82a28-ea0b-11e6-8add-bb2edf7a941b.png)

to this:


![captura de pantalla 2017-02-03 a las 12 22 29 pm](https://cloud.githubusercontent.com/assets/4930129/22601110/7804f438-ea0b-11e6-85f6-8522a4ea8877.png)
