### PR TITLE
WIP: Enabled pylint tests in pytest

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,11 +12,22 @@ no-docstring-rgx = __.*__$|setUp$|setUpClass$|tearDown$|tearDownClass$|Meta$
 generated-members =
     status_code
 ignored-classes=
-	six,
-	six.moves,
+    six,
+    six.moves,
 ignored-modules=
-	six,
-	six.moves,
+    six,
+    six.moves,
 
 [MESSAGES CONTROL]
-disable = no-member, old-style-class, no-init, too-few-public-methods, abstract-method, invalid-name, too-many-ancestors, line-too-long, no-self-use
+disable =
+    no-member,
+    old-style-class,
+    no-init,
+    too-few-public-methods,
+    abstract-method,
+    invalid-name,
+    too-many-ancestors,
+    line-too-long,
+    no-self-use,
+    missing-docstring,
+

--- a/.pylintrc
+++ b/.pylintrc
@@ -29,5 +29,7 @@ disable =
     too-many-ancestors,
     line-too-long,
     no-self-use,
-    missing-docstring,
+    missing-docstring
 
+[SIMILARITIES]
+min-similarity-lines=6

--- a/main.py
+++ b/main.py
@@ -5,25 +5,24 @@ import codecs
 import functools
 import json
 import mimetypes
-import os
-import requests
 import sqlite3
 import string
 import sys
 import urllib
-import web
 
 from datetime import datetime
 from natsort import natsorted
 from requests.exceptions import ConnectionError
 
+import os
+import requests
+import web
 from web.wsgiserver import CherryPyWSGIServer
 
+import settings
 import utilities
 from main_utilities import get_configuration_file, set_configuration_file,\
     set_user_data_file
-import settings
-
 
 # http://pythonhosted.org/PyInstaller/runtime-information.html#run-time-information
 if getattr(sys, 'frozen', False):

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 #!/bin/sh
+# pylint: disable=assigning-non-slot,duplicate-code
 from __future__ import unicode_literals
 
 import codecs
@@ -10,11 +11,11 @@ import string
 import sys
 import urllib
 
+import os
 from datetime import datetime
 from natsort import natsorted
 from requests.exceptions import ConnectionError
 
-import os
 import requests
 import web
 from web.wsgiserver import CherryPyWSGIServer
@@ -33,9 +34,11 @@ else:
 
 CherryPyWSGIServer.ssl_certificate_chain = ''
 try:
+    # pylint: disable=protected-access
     CherryPyWSGIServer.ssl_certificate = "{0}/unplatform/unplatform.cert.dummy.pem".format(sys._MEIPASS)
     CherryPyWSGIServer.ssl_private_key = "{0}/unplatform/unplatform.key.dummy.pem".format(sys._MEIPASS)
 except AttributeError:
+    # pylint: disable=protected-access
     CherryPyWSGIServer.ssl_certificate = "{0}/unplatform/unplatform.cert.dummy.pem".format(ABS_PATH)
     CherryPyWSGIServer.ssl_private_key = "{0}/unplatform/unplatform.key.dummy.pem".format(ABS_PATH)
 
@@ -124,6 +127,7 @@ class bootloader_storage_path:
 
 class index:
     @utilities.format_html_response
+    # pylint: disable=unused-argument
     def GET(self, path=None):
         # reset session on GET index
         # session.login = 0
@@ -249,6 +253,7 @@ class content:
     # whenever content logs to the generic logging API, that will check
     # logged in state.
     # @require_login
+    # pylint: disable=too-many-locals
     def GET(self, path=None):
         full_path = os.path.join(ABS_PATH, 'modules', path)
         if not os.path.isfile(full_path):
@@ -326,6 +331,7 @@ class modules_list:
 class oea_tool:
     @require_login
     @utilities.format_html_response
+    # pylint: disable=unused-argument
     def GET(self, path=None):
         oea_file_path = '{0}/static/oea/index.html'.format(ABS_PATH)
         with open(oea_file_path, 'rb') as oea_index:

--- a/main_utilities.py
+++ b/main_utilities.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code
 # util functions for the classes in main.py
 import os
 import sys

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,10 +1,10 @@
 
 [pytest]
 # addopts = --cov . --cov-config .coveragerc --pep8 --pylint --cov-report term --cov-report html
-addopts =  --disable-pytest-warnings --pep8 --cov . --cov-config .coveragerc --cov-report term --cov-report html
+addopts =  --disable-pytest-warnings --pep8 --pylint --cov . --cov-config .coveragerc --cov-report term --cov-report html
 pep8ignore =
 #    main.py E302 # E302 expected 2 blank lines, found 1
 #    utilities.py E302
-norecursedirs = tool-repos node_modules .git .tox static templates .* CVS _darcs {arch} *.egg
+norecursedirs = node_modules .git .tox static templates .* CVS _darcs {arch} *.egg tool-repos
 
 pep8maxlinelength = 119

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 
 [pytest]
 # addopts = --cov . --cov-config .coveragerc --pep8 --pylint --cov-report term --cov-report html
-addopts =  --disable-pytest-warnings --pep8 --pylint --cov . --cov-config .coveragerc --cov-report term --cov-report html
+addopts =  --disable-pytest-warnings --pep8 --pylint --pylint-rcfile=./.pylintrc --cov . --cov-config .coveragerc --cov-report term --cov-report html
 pep8ignore =
 #    main.py E302 # E302 expected 2 blank lines, found 1
 #    utilities.py E302

--- a/testing_utilities.py
+++ b/testing_utilities.py
@@ -1,13 +1,12 @@
-import glob
+# pylint: disable=duplicate-code
 import json
 import sys
 import os
-from unittest import TestCase
 
-from nose.tools import *
+# from nose.tools import *
 # from paste.fixture import TestApp
-from webtest import TestApp
 from unittest import TestCase
+from webtest import TestApp
 
 from main import app
 from session_migration import create_session_database

--- a/testing_utilities.py
+++ b/testing_utilities.py
@@ -1,7 +1,8 @@
-import os
+import glob
 import json
 import sys
-import glob
+import os
+from unittest import TestCase
 
 from nose.tools import *
 # from paste.fixture import TestApp
@@ -21,8 +22,6 @@ SESSIONS_DB = os.path.join(ABS_PATH, 'unplatform.sqlite3')
 
 
 class BaseTestCase(TestCase):
-    """
-    """
     @staticmethod
     def _filename(file_object):
         return file_object.name.split('/')[-1]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,5 @@
+# pylint: disable=unused-argument
+
 import glob
 import json
 import shutil

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -122,10 +122,7 @@ def mocked_logging_get(*args, **kwargs):
             return self.json_data
     if args[0] == "https://localhost:8080/api/v1/logging/logs":
         return MockResponse([SAMPLE_LOG], 200)
-    else:
-        return MockResponse([SAMPLE_ENTRY], 200)
-
-    return MockResponse({}, 404)
+    return MockResponse([SAMPLE_ENTRY], 200)
 
 
 class BaseMainTestCase(BaseTestCase):
@@ -150,6 +147,7 @@ class BasicServiceTests(BaseMainTestCase):
         return num_sessions
 
     def setUp(self):
+        # pylint: disable=useless-super-delegation
         super(BasicServiceTests, self).setUp()
         # self.data_dir = '{0}/webapps/unplatform/sessions'.format(ABS_PATH)
         # if os.path.isdir(self.data_dir):
@@ -157,6 +155,7 @@ class BasicServiceTests(BaseMainTestCase):
         # os.mkdir(self.data_dir)
 
     def tearDown(self):
+        # pylint: disable=useless-super-delegation
         super(BasicServiceTests, self).tearDown()
         # if os.path.isdir(self.data_dir):
         #     shutil.rmtree(self.data_dir)
@@ -308,6 +307,7 @@ class ModuleDirectoryListingTests(BaseMainTestCase):
         self.url = '/modules_list'
 
     def tearDown(self):
+        # pylint: disable=useless-super-delegation
         super(ModuleDirectoryListingTests, self).tearDown()
 
     def test_can_get_modules_listing(self):
@@ -438,6 +438,7 @@ class LoggingTests(BaseMainTestCase):
         #     shutil.rmtree(self.data_dir)
 
     def tearDown(self):
+        # pylint: disable=useless-super-delegation
         super(LoggingTests, self).tearDown()
         # if os.path.isdir(self.data_dir):
         #     shutil.rmtree(self.data_dir)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,11 +1,12 @@
 import glob
 import json
-import os
-import mock
 import shutil
 import sqlite3
 
 from copy import deepcopy
+
+import os
+import mock
 
 from testing_utilities import BaseTestCase
 
@@ -13,66 +14,66 @@ PROJECT_PATH = os.path.dirname(os.path.abspath(__file__))
 ABS_PATH = '{0}'.format(os.path.abspath(os.path.join(PROJECT_PATH, os.pardir)))
 
 SAMPLE_LOG = {
-  "recordTypeIds": [],
-  "id": "logging.Log%3A57b9547bed849b7a4208596b%40ODL.MIT.EDU",
-  "displayName": {
-    "text": "Default CLIx log",
-    "languageTypeId": "639-2%3AENG%40ISO",
-    "formatTypeId": "TextFormats%3APLAIN%40okapia.net",
-    "scriptTypeId": "15924%3ALATN%40ISO"
-  },
-  "description": {
-    "text": "For logging info from unplatform and tools, which do not know about catalog IDs",
-    "languageTypeId": "639-2%3AENG%40ISO",
-    "formatTypeId": "TextFormats%3APLAIN%40okapia.net",
-    "scriptTypeId": "15924%3ALATN%40ISO"
-  },
-  "genusTypeId": "log-genus-type%3Adefault-clix%40ODL.MIT.EDU"
+    "recordTypeIds": [],
+    "id": "logging.Log%3A57b9547bed849b7a4208596b%40ODL.MIT.EDU",
+    "displayName": {
+        "text": "Default CLIx log",
+        "languageTypeId": "639-2%3AENG%40ISO",
+        "formatTypeId": "TextFormats%3APLAIN%40okapia.net",
+        "scriptTypeId": "15924%3ALATN%40ISO"
+    },
+    "description": {
+        "text": "For logging info from unplatform and tools, which do not know about catalog IDs",
+        "languageTypeId": "639-2%3AENG%40ISO",
+        "formatTypeId": "TextFormats%3APLAIN%40okapia.net",
+        "scriptTypeId": "15924%3ALATN%40ISO"
+    },
+    "genusTypeId": "log-genus-type%3Adefault-clix%40ODL.MIT.EDU"
 }
 
 SAMPLE_ENTRY = {
-  "id": "logging.LogEntry%3A57bfcc5ced849b11f52fc82a%40ODL.MIT.EDU",
-  "displayName": {
-    "text": "",
-    "languageTypeId": "639-2%3AENG%40ISO",
-    "scriptTypeId": "15924%3ALATN%40ISO",
-    "formatTypeId": "TextFormats%3APLAIN%40okapia.net"
-  },
-  "description": {
-    "text": "",
-    "languageTypeId": "639-2%3AENG%40ISO",
-    "scriptTypeId": "15924%3ALATN%40ISO",
-    "formatTypeId": "TextFormats%3APLAIN%40okapia.net"
-  },
-  "recordTypeIds": [
-    "logging.LogEntry%3Atext-blob%40ODL.MIT.EDU"
-  ],
-  "text": {
-    "text": """{\"action\": \"pause audio\",
-        \"questionId\": \"assessment.Item%3A57b954e0ed849b7a420859dc%40ODL.MIT.EDU\",
-        \"assessmentOfferedId\": \"assessment.AssessmentOffered:57bfcc21ed849b11f52fc80a@ODL.MIT.EDU\",
-        \"mediaId\": \"\",
-        \"mediaTime\": 9.142857}""",
-    "languageTypeId": "639-2%3AENG%40ISO",
-    "formatTypeId": "TextFormats%3APLAIN%40okapia.net",
-    "scriptTypeId": "15924%3ALATN%40ISO"
-  },
-  "priorityId": "NoneType%3ANONE%40dlkit.mit.edu",
-  "genusTypeId": "GenusType%3ADEFAULT%40DLKIT.MIT.EDU",
-  "timestamp": {
-    "hour": 4,
-    "month": 8,
-    "second": 4,
-    "microsecond": 157476,
-    "year": 2016,
-    "tzinfo": None,
-    "day": 26,
-    "minute": 58
-  },
-  "assignedLogIds": [
-    "logging.Log%3A57b9547bed849b7a4208596b%40ODL.MIT.EDU"
-  ],
-  "agentId": "osid.agent.Agent%3Aexternal_identifier%40MIT-ODL"
+    "id": "logging.LogEntry%3A57bfcc5ced849b11f52fc82a%40ODL.MIT.EDU",
+    "displayName": {
+        "text": "",
+        "languageTypeId": "639-2%3AENG%40ISO",
+        "scriptTypeId": "15924%3ALATN%40ISO",
+        "formatTypeId": "TextFormats%3APLAIN%40okapia.net"
+    },
+    "description": {
+        "text": "",
+        "languageTypeId": "639-2%3AENG%40ISO",
+        "scriptTypeId": "15924%3ALATN%40ISO",
+        "formatTypeId": "TextFormats%3APLAIN%40okapia.net"
+    },
+    "recordTypeIds": [
+        "logging.LogEntry%3Atext-blob%40ODL.MIT.EDU"
+    ],
+    "text": {
+        "text": """{\"action\": \"pause audio\",
+            \"questionId\": \"assessment.Item%3A57b954e0ed849b7a420859dc%40ODL.MIT.EDU\",
+            \"assessmentOfferedId\": \"assessment.AssessmentOffered:57bfcc21ed849b11f52fc80a@ODL.MIT.EDU\",
+            \"mediaId\": \"\",
+            \"mediaTime\": 9.142857}""",
+        "languageTypeId": "639-2%3AENG%40ISO",
+        "formatTypeId": "TextFormats%3APLAIN%40okapia.net",
+        "scriptTypeId": "15924%3ALATN%40ISO"
+    },
+    "priorityId": "NoneType%3ANONE%40dlkit.mit.edu",
+    "genusTypeId": "GenusType%3ADEFAULT%40DLKIT.MIT.EDU",
+    "timestamp": {
+        "hour": 4,
+        "month": 8,
+        "second": 4,
+        "microsecond": 157476,
+        "year": 2016,
+        "tzinfo": None,
+        "day": 26,
+        "minute": 58
+    },
+    "assignedLogIds": [
+        "logging.Log%3A57b9547bed849b7a4208596b%40ODL.MIT.EDU"
+    ],
+    "agentId": "osid.agent.Agent%3Aexternal_identifier%40MIT-ODL"
 }
 
 
@@ -350,14 +351,14 @@ class ConfigurationTests(BaseMainTestCase):
                             headers={'content-type': 'application/json'})
         self.ok(req)
         data = self.json(req)
-        for key in payload.keys():
+        for key in payload:
             self.assertEqual(data[key], payload[key])
         self.assertIn('timestamp', data.keys())
 
         self.assertTrue(os.path.isfile(self.config_file))
         with open(self.config_file, 'rb') as config:
             conf = json.load(config)
-            for key in data.keys():
+            for key in data:
                 self.assertEqual(conf[key], data[key])
 
     def test_can_get_config(self):
@@ -374,14 +375,14 @@ class ConfigurationTests(BaseMainTestCase):
                             headers={'content-type': 'application/json'})
         self.ok(req)
         data = self.json(req)
-        for key in payload.keys():
+        for key in payload:
             self.assertEqual(data[key], payload[key])
         self.assertIn('timestamp', data.keys())
 
         req = self.app.get(self.url)
         self.ok(req)
         get_data = self.json(req)
-        for key in payload.keys():
+        for key in payload:
             self.assertEqual(get_data[key], payload[key])
         self.assertIn('timestamp', get_data.keys())
 
@@ -419,7 +420,7 @@ class UserSurveyTests(BaseMainTestCase):
             with open(user_file, 'rb') as user_data:
                 data = json.load(user_data)
                 self.assertIn('timestamp', data.keys())
-                for key in payload.keys():
+                for key in payload:
                     self.assertEqual(payload[key], data[key])
 
 

--- a/utilities.py
+++ b/utilities.py
@@ -49,10 +49,9 @@ def format_response(func):
         web.header("Access-Control-Allow-Headers", CORS_HEADERS)
         web.header("Access-Control-Allow-Methods", "GET, POST, OPTIONS, PUT, DELETE")
         web.header("Access-Control-Max-Age", "1728000")
-        if isinstance(results, dict) or isinstance(results, list):
+        if isinstance(results, (dict, list)):
             return json.dumps(results)
-        else:
-            return results
+        return results
     return wrapper
 
 
@@ -69,8 +68,7 @@ def format_xml_response(func):
         web.header("Access-Control-Max-Age", "1728000")
         if isinstance(results, dict):
             return json.dumps(results)
-        else:
-            return results
+        return results
     return wrapper
 
 

--- a/utilities.py
+++ b/utilities.py
@@ -10,6 +10,7 @@ class BaseClass:
     def __init__(self):
         pass
 
+    # pylint: disable=unused-argument
     def OPTIONS(self, *args, **kwargs):
         # https://www.youtube.com/watch?v=gZelOtYjYv8
         web.header("Access-Control-Allow-Origin", "*")


### PR DESCRIPTION
Added ``pylint`` to ``addopts`` in ``pytest.ini``.  This
adds pylint tests to the test suite.

Currently returns pylint validation errors on things we may or may not want to fix.  These errors cause the ``travis-ci`` build to fail.

@cjshawMIT 