### PR TITLE
fix styling on survey page

### DIFF
--- a/ui/src/containers/ActivitiesContainer.js
+++ b/ui/src/containers/ActivitiesContainer.js
@@ -13,7 +13,8 @@ const mapStateToProps = (state, ownProps) => {
     unitName: ownProps.params.unitName,
     gradeName: ownProps.params.gradeName,
     subjectName: ownProps.params.subjectName,
-    strings: localizeStrings(state, ownProps)
+    strings: localizeStrings(state, ownProps),
+    version: state.version.version ? state.version.version : 'unknown'
   }
 }
 

--- a/ui/src/routes/Home/components/HomeView.js
+++ b/ui/src/routes/Home/components/HomeView.js
@@ -111,52 +111,46 @@ class HomeView extends Component {
     let className = "user-select"
     let checked = false
     if (this.props.survey && this.props.survey.userType === label) {
-      // className = "button-gradient-active"
+      className = "user-select button-gradient-active"
       checked = true
     }
     return (
       <div className={className}>
-      <label key={index}
-        // style={[styles.button, styles.userSelectButton]}
-        // className={className}
-        // tabIndex={0}
-        >
-        <input key={index}
-          onChange={(e) => this._onHandleUserTypeSelect(e)}
-          type="radio"
-          name="userType"
-          value={label}
-          // tabIndex={-1}
-          checked={checked}
-          className="user-select__input"
-          ref={(input) => { this.inputField = input; }}
-          />
-        {label}
-      </label>
+        <label key={index}>
+          <input key={index}
+            onChange={(e) => this._onHandleUserTypeSelect(e)}
+            type="radio"
+            name="userType"
+            value={label}
+            checked={checked}
+            className="user-select__input"
+            ref={(input) => { this.inputField = input; }}
+            />
+          {label}
+        </label>
       </div>
     )
   }
 
   renderUserCountButtons = (label, index) => {
-    let className = "button-gradient"
+    let className = "count-select"
+    let checked = false
     if (this.props.survey && this.props.survey.userCount === label) {
-      className = "button-gradient-active"
+      className = "count-select button-gradient-active"
+      checked = true
     }
     return (
-      <label key={index}
-        className={className}
-        // tabIndex={0}
-        style={[styles.button, styles.userSelectButton]}
-        >
-        <input key={index}
-          onChange={(e) => this._onHandleUserCountSelect(e)}
-          type="radio"
-          name="userCount"
-          value={label}
-          // tabIndex={-1}
-          checked={this.props.survey.userCount === label}/>
+      <div className={className}>
+        <label key={index}>
+          <input key={index}
+            onChange={(e) => this._onHandleUserCountSelect(e)}
+            type="radio"
+            name="userCount"
+            value={label}
+            checked={checked} />
           {label}
-      </label>
+        </label>
+      </div>
     )
   }
 
@@ -176,12 +170,16 @@ class HomeView extends Component {
     let userCount
     if (this.props.survey && this.props.survey.userType && this._getEnglishUserType() !== 'demonstration') {
       userCount = (
-        <div>
-          <h3 className="count users-count">{this.props.strings.splash.prompt}</h3>
-          <article className="count-select">
-            {_.map(['1', '2', '3', '3+'], this.renderUserCountButtons)}
-          </article>
-        </div>
+        <form action="" className="count-select-form">
+          <fieldset>
+            <legend>
+              <h2 className="pg-subtitle">{this.props.strings.splash.prompt}</h2>
+            </legend>
+            <article className="but-select">
+              {_.map(['1', '2', '3', '3+'], this.renderUserCountButtons)}
+            </article>
+          </fieldset>
+        </form>
       )
     }
 

--- a/ui/src/routes/Home/components/HomeView.js
+++ b/ui/src/routes/Home/components/HomeView.js
@@ -116,8 +116,10 @@ class HomeView extends Component {
     }
     return (
       <div className={className}>
-        <label key={index}>
+        <label key={index}
+          htmlFor={label}>
           <input key={index}
+            id={label}
             onChange={(e) => this._onHandleUserTypeSelect(e)}
             type="radio"
             name="userType"
@@ -141,12 +143,14 @@ class HomeView extends Component {
     }
     return (
       <div className={className}>
-        <label key={index}>
+        <label key={index}
+          htmlFor={label}>
           <input key={index}
             onChange={(e) => this._onHandleUserCountSelect(e)}
             type="radio"
             name="userCount"
             value={label}
+            id={label}
             checked={checked} />
           {label}
         </label>

--- a/ui/src/styles/core.css
+++ b/ui/src/styles/core.css
@@ -144,11 +144,6 @@ nav {
   justify-content: center;
 }
 
-.count-select {
-  padding-top: 1.5rem;
-  border-top: 2px solid hsla(327, 100%, 70%, 1);
-}
-
 .subj-select {
   display: inline-flex;
   align-items: center;
@@ -158,22 +153,25 @@ nav {
   text-align: center;
 }
 
-.user-select-form fieldset {
+.user-select-form fieldset,
+.count-select-form fieldset {
   margin-top: 0.5rem;
 }
 
-.user-select-form legend {
+.user-select-form legend,
+.count-select-form legend {
   text-align: center;
 }
 
 
 /* BUTTONS */
 
-.user-select {
+.user-select,
+.count-select {
   width: 13.5rem;
   height: 3.125rem;
   margin: 0.313rem;
-  padding: 0 0.5rem;
+  /*padding: 0 0.5rem;*/
 /*  clix-blue-purp*/
   background: radial-gradient(circle at 50% 50%, hsla(259, 40%, 40%, 0.5), hsla(259, 40%,30%, 0.5));
   border: solid 0.094rem #ffffff;
@@ -190,18 +188,28 @@ nav {
   align-items: center;
 }
 
-.user-select:hover {
+.user-select:hover,
+.count-select:hover {
   /*clix-magenta*/
   background: radial-gradient(circle at 50% 50%, hsla(327, 100%, 45%, 0.9), hsla(327, 100%, 35%, 0.6));
 }
 
-.user-select:active {
+.user-select:active,
+.count-select:active {
   /*clix-magenta*/
   background: radial-gradient(circle at 50% 50%, hsla(327, 100%, 35%, 0.9), hsla(327, 100%, 25%, 0.6));
   color: #fff;
 }
 
-.user-select input[type="radio"] {
+.user-select label,
+.count-select label {
+  width: 100%;
+  height: 100%;
+  padding-top: 0.7em;
+}
+
+.user-select input[type="radio"],
+.count-select input[type="radio"] {
   height: 0.006rem;
   width:0.006rem;
   position: absolute;


### PR DESCRIPTION
1. Make DOM elements consistent between `user-select` and `count-select`.
2. Make CSS consistent between `user-select` and `count-select`.
3. Make `label` element larger in both forms, so that you can click anywhere in the `div` button to select the input.

The `Select Subject` button has better margins as a result of the above.

Addresses issue #65 .