### PR TITLE
Hotfix/cs/update run kitty run repo

### DIFF
--- a/modules/Tools/Run Kitty Run/index.html
+++ b/modules/Tools/Run Kitty Run/index.html
@@ -1,1 +1,1 @@
-<iframe name="frame" frameBorder="0" src="/static/biomechanic/index.html" style="position: absolute; left: 0; top: 0; width: 100%; height:100vh;" allowfullscreen></iframe>
+<iframe name="frame" frameBorder="0" src="/static/runkittyrun/index.html" style="position: absolute; left: 0; top: 0; width: 100%; height:100vh;" allowfullscreen></iframe>

--- a/scripts/build_scripts/build_script_all_ssl.sh
+++ b/scripts/build_scripts/build_script_all_ssl.sh
@@ -227,17 +227,17 @@ rm -rf $BUILD_ROOT/bundle/static/oea/.git/
 echo Processing Biomechanics game
 cd $BUILD_ROOT/tool-repos
 
-if [ ! -d "biomechanic" ]
+if [ ! -d "runkittyrun" ]
 then
-  git clone git@github.com:CLIxIndia-Dev/biomechanic.git
+  git clone git@github.com:CLIxIndia-Dev/runkittyrun.git
 fi
-cd biomechanic
-git checkout release
-git pull origin release
+cd runkittyrun
+git checkout master
+git pull origin master
 cd ..
-mkdir $BUILD_ROOT/bundle/static/biomechanic/
-cp -rf biomechanic/* $BUILD_ROOT/bundle/static/biomechanic/
-rm -rf $BUILD_ROOT/bundle/static/biomechanic/.git/
+mkdir $BUILD_ROOT/bundle/static/runkittyrun/
+cp -rf runkittyrun/en/* $BUILD_ROOT/bundle/static/runkittyrun/
+rm -rf $BUILD_ROOT/bundle/static/runkittyrun/.git/
 
 # Physics Video player
 echo Processing Physics Video player
@@ -277,11 +277,11 @@ then
   git clone git@github.com:CLIxIndia-Dev/policequad.git
 fi
 cd policequad
-git checkout English
-git pull origin English
+git checkout master
+git pull origin master
 cd ..
 mkdir $BUILD_ROOT/bundle/static/policequad/
-cp -rf policequad/*  $BUILD_ROOT/bundle/static/policequad/
+cp -rf policequad/en/*  $BUILD_ROOT/bundle/static/policequad/
 rm -rf $BUILD_ROOT/bundle/static/policequad/.git/
 
 # Open Story tool

--- a/scripts/build_scripts/build_script_all_ssl.sh
+++ b/scripts/build_scripts/build_script_all_ssl.sh
@@ -127,7 +127,7 @@ then
   mkdir -p $BUILD_ROOT/static/content
 fi
 
-pytest
+pytest --no-cov
 
 # Now move the generated UI files to the bundle
 mv $BUILD_ROOT/static/ui/* $BUILD_ROOT/bundle/static/ui/


### PR DESCRIPTION
This updates the build script:

1) to use the renamed `runkittyrun` repo.
2) to use the `police quad` `en` folder, instead of the `English` branch.