### PR TITLE
Hotfix/cs/session database locking

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import json
 import mimetypes
 import os
 import requests
+import sqlite3
 import string
 import sys
 import urllib
@@ -64,6 +65,9 @@ web.config.session_parameters['timeout'] = 20 * 60  # 20 minutes of inactivity
 # when using filesystem
 db = web.database(dbn='sqlite', db='unplatform.sqlite3')
 store = web.session.DBStore(db, 'sessions')
+
+connection = sqlite3.connect('unplatform.sqlite3')
+connection.execute('PRAGMA journal_mode=WAL;')
 
 session = web.session.Session(app,
                               store,

--- a/scripts/build_scripts/build_script_all_ssl.sh
+++ b/scripts/build_scripts/build_script_all_ssl.sh
@@ -54,6 +54,12 @@ if [ -f $BUILD_ROOT/unplatform.sqlite3 ]
 then
   rm $BUILD_ROOT/unplatform.sqlite3
 fi
+# remove the sqlite3 database WAL files
+if [ -f $BUILD_ROOT/unplatform.sqlite3-shm ]
+then
+  rm $BUILD_ROOT/unplatform.sqlite3-shm
+  rm $BUILD_ROOT/unplatform.sqlite3-wal
+fi
 
 if [ ! -d $BUILD_ROOT/bundle ]
 then
@@ -82,6 +88,8 @@ cp $BUILD_ROOT/templates/* bundle/templates/
 cd $BUILD_ROOT
 python session_migration.py
 mv $BUILD_ROOT/unplatform.sqlite3 $BUILD_ROOT/bundle/
+mv $BUILD_ROOT/unplatform.sqlite3-shm $BUILD_ROOT/bundle/
+mv $BUILD_ROOT/unplatform.sqlite3-wal $BUILD_ROOT/bundle/
 
 # update the virtual environment
 pip install -r $BUILD_ROOT/requirements.txt

--- a/session_migration.py
+++ b/session_migration.py
@@ -7,6 +7,7 @@ import sqlite3
 def create_session_database():
     connection = sqlite3.connect('unplatform.sqlite3')
     with open('sql/session_schema.sql', 'rb') as session_schema:
+        connection.execute('PRAGMA journal_mode=WAL;')
         c = connection.cursor()
         c.execute(session_schema.read())
         connection.commit()


### PR DESCRIPTION
Configures the sqlite3 session database to use [Write-Ahead Locking](http://www.sqlite.org/wal.html), which makes it handle concurrency better.

This change is needed because some resource-heavy apps (like StarLogo) use 75+ HTTP requests to get all their JS / CSS / image files, which overloads the session management and causes database locks on slower machines (i.e. ncomputing). This change seems to remove that error. @