### PR TITLE
Feature/cs/student id input field

### DIFF
--- a/ui/src/locale/en.js
+++ b/ui/src/locale/en.js
@@ -38,7 +38,9 @@ export default {
       student: 'Student', // demographic option
       visitor: 'Visitor/Other', // demographic option
       demonstration: 'Class Demonstration', // demographic option
-      prompt: 'How many users are at this computer?' // prompt
+      prompt: 'How many users are at this computer?', // prompt
+      usernameLabel: 'Student IDs (optional).',  // label for the username input field
+      usernamePlaceholder: 'Please type in your student IDs, like: 100, 120, and 97'  // placeholder for the username input field
     }
   }
 }

--- a/ui/src/locale/hi.js
+++ b/ui/src/locale/hi.js
@@ -37,7 +37,7 @@ export default {
       demonstration: 'वर्ग प्रदर्शन', // demographic option
       prompt: 'इस कंप्यूटर पर कितने यूजर हैं?', // prompt
       usernameLabel: 'छात्र आईडी (वैकल्पिक).',  // label for the username input field
-      usernamePlaceholder: 'कृपया अपने छात्र आईडी टाइप करें (वैकल्पिक).'  // placeholder for the username input field
+      usernamePlaceholder: 'कृपया अपने छात्र आईडी टाइप करें, जैसे: 100, 120, और 97'  // placeholder for the username input field
     }
   }
 }

--- a/ui/src/locale/hi.js
+++ b/ui/src/locale/hi.js
@@ -35,7 +35,9 @@ export default {
       student: 'छात्र', // demographic option
       visitor: 'प्रतिभागी/अन्य', // demographic option
       demonstration: 'वर्ग प्रदर्शन', // demographic option
-      prompt: 'इस कंप्यूटर पर कितने यूजर हैं?' // prompt
+      prompt: 'इस कंप्यूटर पर कितने यूजर हैं?', // prompt
+      usernameLabel: 'छात्र आईडी (वैकल्पिक).',  // label for the username input field
+      usernamePlaceholder: 'कृपया अपने छात्र आईडी टाइप करें (वैकल्पिक).'  // placeholder for the username input field
     }
   }
 }

--- a/ui/src/locale/te.js
+++ b/ui/src/locale/te.js
@@ -37,7 +37,7 @@ export default {
       demonstration: 'క్లాస్ ప్రదర్శన', // demographic option
       prompt: 'ఎంతమంది ఈ కంప్యూటర్ వద్ద ఉన్నాయి?', // prompt
       usernameLabel: 'విద్యార్థి ID లు (ఐచ్ఛికం).',  // label for the username input field
-      usernamePlaceholder: 'దయచేసి మీ విద్యార్థి ID లలో (ఐచ్ఛిక) టైప్ చేయండి.'  // placeholder for the username input field
+      usernamePlaceholder: 'దయచేసి 100, 120 మరియు 97 వంటి మీ విద్యార్థి ID లలో టైప్ చేయండి'  // placeholder for the username input field
     }
   }
 }

--- a/ui/src/locale/te.js
+++ b/ui/src/locale/te.js
@@ -35,7 +35,9 @@ export default {
       student: 'విద్యార్థి', // demographic option
       visitor: 'సందర్శకుల / ఇతర', // demographic option
       demonstration: 'క్లాస్ ప్రదర్శన', // demographic option
-      prompt: 'ఎంతమంది ఈ కంప్యూటర్ వద్ద ఉన్నాయి?' // prompt
+      prompt: 'ఎంతమంది ఈ కంప్యూటర్ వద్ద ఉన్నాయి?', // prompt
+      usernameLabel: 'విద్యార్థి ID లు (ఐచ్ఛికం).',  // label for the username input field
+      usernamePlaceholder: 'దయచేసి మీ విద్యార్థి ID లలో (ఐచ్ఛిక) టైప్ చేయండి.'  // placeholder for the username input field
     }
   }
 }

--- a/ui/src/reducers/Survey/Survey.js
+++ b/ui/src/reducers/Survey/Survey.js
@@ -15,7 +15,7 @@ const initialState = {
 export default function surveyReducer (state = initialState, action) {
   switch (action.type) {
     case RECEIVE_CLEAR_SURVEY:
-      return {data: {}}
+      return { data: {} }
 
     case RECEIVE_UPDATE_SURVEY:
       return _.assign({}, state, {

--- a/ui/src/reducers/Survey/setSurvey.js
+++ b/ui/src/reducers/Survey/setSurvey.js
@@ -34,9 +34,9 @@ export function setSurvey (data) {
     return axios(options)
     .then((response) => {
       // console.log(response.data)
-
-      Cookies.set('session_id', response.data.sessionId)
-      dispatch(receiveSetSurvey(response.data.sessionId))
+      const sessionId = response.data.username || response.data.sessionId
+      Cookies.set('session_id', sessionId)
+      dispatch(receiveSetSurvey(sessionId))
     })
     .catch((error) => {
       console.log('error setting survey into session', error)

--- a/ui/src/routes/Home/components/HomeView.js
+++ b/ui/src/routes/Home/components/HomeView.js
@@ -19,7 +19,8 @@ class HomeView extends Component {
         state: { setFocus: true }
       },
       focusedItem: null,
-      focusedCount: null
+      focusedCount: null,
+      username: null
     }
   }
 
@@ -132,14 +133,33 @@ class HomeView extends Component {
     let userCount
     if (this.props.survey && this.props.survey.userType && this._getEnglishUserType() !== 'demonstration') {
       userCount = (
-        <fieldset className='count-select-form'>
-          <legend>
-            <h3 className='pg-heading-3'>{this.props.strings.splash.prompt}</h3>
-          </legend>
-          <article className='input-select__wrapper'>
-            {_.map(['1', '2', '3', '3+'], this.renderUserCountButtons)}
-          </article>
-        </fieldset>
+        <div>
+          <fieldset className='count-select-form'>
+            <legend>
+              <h3 className='pg-heading-3'>{this.props.strings.splash.prompt}</h3>
+            </legend>
+            <article className='input-select__wrapper'>
+              {_.map(['1', '2', '3', '3+'], this.renderUserCountButtons)}
+            </article>
+          </fieldset>
+          <fieldset className='username-input-form'>
+            <article className='username-input-form__wrapper'>
+              <label
+                htmlFor='studentIds'
+                className='c-survey__form--label'>
+                {this.props.strings.splash.usernameLabel}
+              </label>
+              <input
+                id='studentIds'
+                type='text'
+                placeholder={this.props.strings.splash.usernamePlaceholder}
+                value={this.state.username}
+                className='c-survey__form--input'
+                onChange={(e) => { this.setState({ username: e.target.value }) }}
+              />
+            </article>
+          </fieldset>
+        </div>
       )
     }
 
@@ -184,7 +204,12 @@ class HomeView extends Component {
               </ul>
             </nav>
           </header>
-          <main role='main' aria-label='content' id='main' tabIndex='-1' className='span_11_of_12 main-content homeview__content' >
+          <main
+            role='main'
+            aria-label='content'
+            id='main'
+            tabIndex='-1'
+            className='span_11_of_12 main-content homeview__content' >
             <h1 className='pg-heading-1'>
               <span aria-hidden>{this.props.strings.splash.title}</span>
               <span className='visuallyhidden'>{this.props.strings.splash.ariaLabelTitle}</span>
@@ -241,7 +266,8 @@ class HomeView extends Component {
   _onHandleSubmit () {
     this.props.onSetSurvey({
       userType: this._getEnglishUserType(),
-      userCount: this.props.survey.userCount
+      userCount: this.props.survey.userCount,
+      username: this.state.username
     })
     browserHistory.push('/subjects')
   }

--- a/ui/src/styles/core.css
+++ b/ui/src/styles/core.css
@@ -464,6 +464,31 @@ dialog.fixed {
   background: radial-gradient(circle at 50% 50%, hsla(327, 100%, 45%, 0.9), hsla(327, 100%, 35%, 0.3));
 }
 
+/* Username input fields */
+.username-input-form .username-input-form__wrapper {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  justify-content: center;
+  max-width: 600px;
+  padding: 0.5em 0.875em;
+  margin: 1rem auto 1.3rem;
+}
+
+.username-input-form label {
+  margin-top: 0.8em;
+  margin-bottom: 0.5em;
+  font-family: open_sansbold;
+  font-size: 0.875em;
+  color: white;
+}
+
+.username-input-form input {
+  margin-bottom: 0.5em;
+  padding: 0.29em;
+  font-size: 0.875em;
+}
+
 /* BACKGROUND */
 
 .bg-img {


### PR DESCRIPTION
Request for added field from Brandon M. "username" can be a list of student IDs or strings, like `blue-whale` or `123, 124, and 100`. Should accept unicode too, if someone decides to use it.

If provided, this replaces the server-generated sessionId for OEA and for logging. You can check this by running the app, and check the Network tab of dev tools. When a logging event takes place (i.e. clicking on a subject button), the `sessionId` value sent to the server should be the `username` you typed in. If you leave the field blank, a server-generated session ID should be sent instead.