### PR TITLE
manually copy in bs4 license file

### DIFF
--- a/LICENSE_BeautifulSoup4.txt
+++ b/LICENSE_BeautifulSoup4.txt
@@ -1,0 +1,27 @@
+Beautiful Soup is made available under the MIT license:
+
+ Copyright (c) 2004-2016 Leonard Richardson
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+Beautiful Soup incorporates code from the html5lib library, which is
+also made available under the MIT license. Copyright (c) 2006-2013
+James Graham and other contributors

--- a/scripts/build_scripts/build_script_all_ssl.sh
+++ b/scripts/build_scripts/build_script_all_ssl.sh
@@ -712,6 +712,12 @@ esac
 echo QBank-lite binary is $QBANK_FILE
 cp $QBANK_FILE  $BUILD_ROOT/bundle/
 
+# Manually copy BeautifulSoup4 license over, because it is missing
+#   from the .tar.gz file downloaded from PyPI.
+echo Manually copying BeautifulSoup4 license
+cp $BUILD_ROOT/LICENSE_BeautifulSoup4.txt $BUILD_ROOT/bundle/licenses/beautifulsoup4
+
+
 # Zip up the final bundle/ directory and name the file per the unplatform version
 VERSION=$(python -c "import json; print json.load(open('package.json', 'rb'))['version']")
 


### PR DESCRIPTION
Their LICENSE file isn't included in the `tar.gz` from PyPI, so we include it manually.