### PR TITLE
change OEA config to formative so no alert

### DIFF
--- a/scripts/oea_build_config/_head.html
+++ b/scripts/oea_build_config/_head.html
@@ -22,7 +22,7 @@
     bank:          "assessment.Bank%3A577fcf7cc89cd90cbd5616fa%40ODL.MIT.EDU",
     assessment_offered_id: "assessment.AssessmentOffered%3A58824256c89cd9741bab8942%40ODL.MIT.EDU",
     lambda_url: '',
-    assessment_kind: "SUMMATIVE",
+    assessment_kind: "FORMATIVE",
     qBankHost: 'https://localhost:8080/api/v1',
     assessmentPlayerUrl: 'https://localhost:8888/static/oea/index.html',
     editableBankId: 'assessment.Bank%3A588f9225c89cd977c3560780%40ODL.MIT.EDU',


### PR DESCRIPTION
This was advice given to the gstudio team, because that is the behavior they wanted. So making the same change on the unplatform side.