### PR TITLE
build debian package without lintian

### DIFF
--- a/scripts/bundle_executables/debian/build_debian_package.sh
+++ b/scripts/bundle_executables/debian/build_debian_package.sh
@@ -77,7 +77,7 @@ rm -f $BUILD_ROOT/clix/clix-$VERSION/source/unplatform_*.zip
 cd $BUILD_ROOT/clix/clix-$VERSION
 
 echo Building the Debian binary. Please wait.
-debuild -b
+debuild --no-lintian -b
 
 # The output should be something like ``clix/clix-$VERSION_1ubuntu1.deb``
 echo Done building the Debian binary!


### PR DESCRIPTION
We ignore the lintian output anyways, so .... save time when building.