### PR TITLE
add postrm script for debian uninstall

### DIFF
--- a/scripts/build_scripts/build_script_all_ssl.sh
+++ b/scripts/build_scripts/build_script_all_ssl.sh
@@ -686,6 +686,9 @@ case $UN2_BUILD_OS in
 
         # copy over the helper Debian build script
         cp $BUILD_ROOT/scripts/bundle_executables/debian/build_debian_package.sh $BUILD_ROOT/bundle/
+
+        # copy over the postrm script that does a better clean up
+        cp $BUILD_ROOT/scripts/bundle_executables/debian/postrm $BUILD_ROOT/bundle/
         ;;
     'osx')
         cp $BUILD_ROOT/scripts/launchers/unplatform_osx_ssl.sh bundle/

--- a/scripts/bundle_executables/debian/build_debian_package.sh
+++ b/scripts/bundle_executables/debian/build_debian_package.sh
@@ -42,6 +42,7 @@ rm -rf $BUILD_ROOT/clix/clix-$VERSION/debian/README.*
 # Copy over our install and rules files
 cp $BUILD_ROOT/bundle/install $BUILD_ROOT/clix/clix-$VERSION/debian/
 cp $BUILD_ROOT/bundle/rules $BUILD_ROOT/clix/clix-$VERSION/debian/
+cp $BUILD_ROOT/bundle/postrm $BUILD_ROOT/clix/clix-$VERSION/debian/
 
 # Modify the rules file with the current version's path
 WEBAPPS="chmod 777 debian\/clix-$VERSION\/opt\/clix\/webapps"

--- a/scripts/bundle_executables/debian/postrm
+++ b/scripts/bundle_executables/debian/postrm
@@ -1,0 +1,2 @@
+rm -rf /opt/clix/unplatform.sqlite3*
+rm -rf /opt/clix/webapps/


### PR DESCRIPTION
Gets rid of all the new files that might be added when you run the `clix` program, if you uninstall. Default Debian uninstaller removes all the originally installed files already.