### PR TITLE
fix styling on unplatform version in tool view

### DIFF
--- a/ui/src/routes/Tool/Tool.js
+++ b/ui/src/routes/Tool/Tool.js
@@ -120,18 +120,20 @@ class Tool extends Component {
         <div className='act-container'>
           <header role='banner' id='global-nav' tabIndex='-1' className='c-header'>
             <h1 className='c-header__logo'>CLIx Connected Learning Initiative</h1>
-            <p className='c-header--unplat-v'>unplatform version {this.props.version}</p>
-            <nav className='c-header__nav'>
-              <a href='/tools'
-                onClick={this._onChooseTool}>
-                {this.props.strings.unplatformNav.chooseTool}</a>
-              <a href='/subjects'
-                onClick={this._onSelectSubject}>
-                {this.props.strings.breadcrumbs.selectSubject}</a>
-              <button
-                onClick={this._onToggleModal}>
-                {this.props.strings.unplatformNav.finishLesson}</button>
-            </nav>
+            <div className='c-header__nav-wrapper'>
+              <p className='c-header__unplat-v'>unplatform version {this.props.version}</p>
+              <nav className='c-header__nav'>
+                <a href='/tools'
+                  onClick={this._onChooseTool}>
+                  {this.props.strings.unplatformNav.chooseTool}</a>
+                <a href='/subjects'
+                  onClick={this._onSelectSubject}>
+                  {this.props.strings.breadcrumbs.selectSubject}</a>
+                <button
+                  onClick={this._onToggleModal}>
+                  {this.props.strings.unplatformNav.finishLesson}</button>
+              </nav>
+            </div>
           </header>
           <main role='main' aria-label='content' id='main' tabIndex='-1' className='span_12_of_12'>
             <iframe src={toolUrl}


### PR DESCRIPTION
Without this fix, the unplatform version text was centered and unstyled in the header, but only for the `Tool` page:
  
<img width="1408" alt="captura de pantalla 2018-01-08 a la s 3 12 22 pm" src="https://user-images.githubusercontent.com/4930129/34690248-65092990-f486-11e7-9859-58e7c719271f.png">

  