### PR TITLE
second linux script to run from bundle

### DIFF
--- a/scripts/build_scripts/build_script_all_ssl.sh
+++ b/scripts/build_scripts/build_script_all_ssl.sh
@@ -673,6 +673,7 @@ case $UN2_BUILD_OS in
        ;;
     'linux')
         cp $BUILD_ROOT/scripts/launchers/unplatform_linux64_ssl.sh bundle/
+        cp $BUILD_ROOT/scripts/launchers/unplatform_linux64_ssl-deb.sh bundle/
         # copy over the Debian rules file
         cp $BUILD_ROOT/scripts/bundle_executables/debian/rules $BUILD_ROOT/bundle/
         # copy over the Debian install file, which copies files to the host

--- a/scripts/bundle_executables/debian/clix.desktop
+++ b/scripts/bundle_executables/debian/clix.desktop
@@ -4,6 +4,6 @@ Version=1.6
 Name=CLIx
 Comment=Connected Learning Initiative
 Icon=clix
-Exec=gnome-terminal --window -e '/opt/clix/unplatform_linux64_ssl.sh'
+Exec=gnome-terminal --window -e '/opt/clix/unplatform_linux64_ssl-deb.sh'
 Path=/opt/clix
 Categories=Education;

--- a/scripts/launchers/unplatform_linux64_ssl-deb.sh
+++ b/scripts/launchers/unplatform_linux64_ssl-deb.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# hardcode the paths since we know the .deb
+#   package installs to /opt/clix.
+gnome-terminal -x bash -c "echo 'Keep this window open to run the CLIx modules.'; /opt/clix/unplatform_linux64_ssl"
+sleep 6
+FILE=$(find . -name qbank-lite*ubuntu* | sort -n | tail -1)
+gnome-terminal -x bash -c "echo 'Keep this window open to run the CLIx assessment engine.'; /opt/clix/$FILE"
+google-chrome https://localhost:8888

--- a/scripts/launchers/unplatform_linux64_ssl.sh
+++ b/scripts/launchers/unplatform_linux64_ssl.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# hardcode the paths since we know the .deb
-#   package installs to /opt/clix.
-gnome-terminal -x bash -c "echo 'Keep this window open to run the CLIx modules.'; /opt/clix/unplatform_linux64_ssl"
+# generate relative paths for running this from a bundle
+UNPLATFORM_WD=`pwd`
+gnome-terminal -x bash -c "echo 'Keep this window open to run the CLIx modules.'; $UNPLATFORM_WD/unplatform_linux64_ssl"
 sleep 6
 FILE=$(find . -name qbank-lite*ubuntu* | sort -n | tail -1)
-gnome-terminal -x bash -c "echo 'Keep this window open to run the CLIx assessment engine.'; /opt/clix/$FILE"
+gnome-terminal -x bash -c "echo 'Keep this window open to run the CLIx assessment engine.'; $UNPLATFORM_WD/$FILE"
 google-chrome https://localhost:8888


### PR DESCRIPTION
When I changed the launch script to use the hardcoded Debian install paths, it broke the ability to run the unplatform directly from a bundle (non-Debian install). This adds a second launch script to account for both use cases.