### PR TITLE
add read-only flag and map to a genusTypeId

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -10,3 +10,6 @@ DEFAULT_ASSESSMENT_GENUS_TYPE = (
 DEFAULT_OFFERED_GENUS_TYPE = (
     'assessment-offered-genus-type%3A'
     'star-logo-nova%40ODL.MIT.EDU')
+READ_ONLY_TAKEN_GENUS_TYPE = (
+    'assessment-taken-genus-type%3A'
+    'star-logo-nova-read-only%40ODL.MIT.EDU')

--- a/star_logo_nova.py
+++ b/star_logo_nova.py
@@ -144,6 +144,13 @@ class SLNProject:
         return SLNProjects(remixes)
 
     @property
+    def read_only(self):
+        """ Returns a boolean if the taken is read-only or not,
+            based on its genusTypeId """
+        return self.my_map['genusTypeId'] == \
+            settings.READ_ONLY_TAKEN_GENUS_TYPE
+
+    @property
     def serialize(self):
         """ turn into the JSON blob that SLN expects """
         return {
@@ -153,7 +160,8 @@ class SLNProject:
             'created_at': self.created_at,
             'saved_at': self.saved_at,
             'parent_project': self.parent_project,
-            'project_str': self.project_str
+            'project_str': self.project_str,
+            'read_only': self.read_only
         }
 
 

--- a/tests/test_sln.py
+++ b/tests/test_sln.py
@@ -525,6 +525,7 @@ class TestSLNProject(BaseMainTestCase):
             'id': 'foo',
             'assignedBankIds': ['bank'],
             'assessmentOfferedId': 'offered',
+            'genusTypeId': 'DEFAULT%3ADEFAULT%40DEFAULT',
             'takingAgentId': 'user',
             'displayName': {
                 'text': 'project'
@@ -782,8 +783,15 @@ class TestSLNProject(BaseMainTestCase):
             'created_at': '2000-01-01T00:00:00.000000Z',
             'saved_at': '1910-10-20T02:05:15.000127Z',
             'parent_project': None,
-            'project_str': expected
+            'project_str': expected,
+            'read_only': False
         }
+
+    def test_can_get_read_only_status(self):
+        assert not self.project.read_only
+        self.project.my_map['genusTypeId'] = \
+            settings.READ_ONLY_TAKEN_GENUS_TYPE
+        assert self.project.read_only
 
 
 class TestSLNProjects(BaseMainTestCase):
@@ -794,6 +802,7 @@ class TestSLNProjects(BaseMainTestCase):
             'id': 'foo',
             'assignedBankIds': ['bank'],
             'assessmentOfferedId': 'offered',
+            'genusTypeId': 'DEFAULT%3ADEFAULT%40DEFAULT',
             'takingAgentId': '%3Auser%40',
             'displayName': {
                 'text': 'project'
@@ -810,6 +819,7 @@ class TestSLNProjects(BaseMainTestCase):
             'id': 'foo2',
             'assignedBankIds': ['bank'],
             'assessmentOfferedId': 'offered',
+            'genusTypeId': 'DEFAULT%3ADEFAULT%40DEFAULT',
             'takingAgentId': '%3Auser2%40',
             'displayName': {
                 'text': 'project2'


### PR DESCRIPTION
Might have to change this depending on the name of the actual field used in StarLogoNova...